### PR TITLE
Add ability to lock units for entire subcultures

### DIFF
--- a/src/script/_lib/mod/vco-commons.lua
+++ b/src/script/_lib/mod/vco-commons.lua
@@ -95,8 +95,8 @@ end
 -- ITEMS --
 
 function vlc.items:add_item_to_faction_inventory(item_key, faction_key)
-    local faction = cm:get_faction(faction_key);
-    cm:add_ancillary_to_faction(faction, item_key, false);
+	local faction = cm:get_faction(faction_key);
+	cm:add_ancillary_to_faction(faction, item_key, false);
 end
 
 -- NAGASH BOOKS --

--- a/src/script/_lib/mod/vco-commons.lua
+++ b/src/script/_lib/mod/vco-commons.lua
@@ -180,11 +180,11 @@ end
 
 function vlc.unit_locks:lock_units_by_subculture(unit_keys_list, subculture_key)
 	local all_subculture_factions = cm:get_factions_by_subculture(subculture_key);
-  for _, unit_key in ipairs(unit_keys_list) do
-  	for _, faction_key in ipairs(all_subculture_factions) do
-  		self:lock_unit(unit_key, faction_key)
-  	end
-  end
+	for _, unit_key in ipairs(unit_keys_list) do
+		for _, faction_key in ipairs(all_subculture_factions) do
+			self:lock_unit(unit_key, faction_key)
+		end
+	end
 end
 
 -- EXPORT --

--- a/src/script/_lib/mod/vco-commons.lua
+++ b/src/script/_lib/mod/vco-commons.lua
@@ -178,6 +178,15 @@ function vlc.unit_locks:unlock_units(unit_keys_list, faction_key)
 	end
 end
 
+function vlc.unit_locks:lock_units_by_subculture(unit_keys_list, subculture_key)
+	local all_subculture_factions = cm:get_factions_by_subculture(subculture_key);
+  for _, unit_key in ipairs(unit_keys_list) do
+  	for _, faction_key in ipairs(all_subculture_factions) do
+  		self:lock_unit(unit_key, faction_key)
+  	end
+  end
+end
+
 -- EXPORT --
 
 core:add_static_object("vco-lib-commons", vlc);

--- a/src/script/campaign/mod/vco-listeners-ksl.lua
+++ b/src/script/campaign/mod/vco-listeners-ksl.lua
@@ -2,6 +2,7 @@ local vlc = core:get_static_object("vco-lib-commons");
 
 local FACTION_TGO_KEY = "wh3_main_ksl_the_great_orthodoxy";
 local FACTION_TIC_KEY = "wh3_main_ksl_the_ice_court";
+local SUBCULTURE_KEY = "wh3_main_sc_ksl_kislev";
 local KEY_D_CALL_FOR_AID = "vco_ksl_kat_dilemma_call_for_aid";
 local KEY_U_GIANT_SLAYERS = "wh2_dlc10_dwf_inf_giant_slayers";
 local KEY_U_GREAT_CANNON = "wh_main_emp_art_great_cannon";
@@ -10,7 +11,7 @@ local KEY_U_MORTAR = "wh_main_emp_art_mortar";
 local KEY_U_SLAYERS = "wh_main_dwf_inf_slayers";
 
 local function tgo_lock_luminark()
-	vlc.unit_locks:lock_unit(KEY_U_LUMINARK, FACTION_TGO_KEY);
+	vlc.unit_locks:lock_units_by_subculture(KEY_U_LUMINARK, SUBCULTURE_KEY);
 end
 
 local function tgo_unlock_luminark()
@@ -18,10 +19,10 @@ local function tgo_unlock_luminark()
 end
 
 local function tic_lock_units()
-	vlc.unit_locks:lock_unit(KEY_U_SLAYERS, FACTION_TIC_KEY);
-	vlc.unit_locks:lock_unit(KEY_U_GIANT_SLAYERS, FACTION_TIC_KEY);
-	vlc.unit_locks:lock_unit(KEY_U_MORTAR, FACTION_TIC_KEY);
-	vlc.unit_locks:lock_unit(KEY_U_GREAT_CANNON, FACTION_TIC_KEY);
+	vlc.unit_locks:lock_units_by_subculture(KEY_U_SLAYERS, SUBCULTURE_KEY);
+	vlc.unit_locks:lock_units_by_subculture(KEY_U_GIANT_SLAYERS, SUBCULTURE_KEY);
+	vlc.unit_locks:lock_units_by_subculture(KEY_U_MORTAR, SUBCULTURE_KEY);
+	vlc.unit_locks:lock_units_by_subculture(KEY_U_GREAT_CANNON, SUBCULTURE_KEY);
 end
 
 local function tic_unlock_dwarf_units()

--- a/src/script/campaign/mod/vco-listeners-nor.lua
+++ b/src/script/campaign/mod/vco-listeners-nor.lua
@@ -2,6 +2,7 @@ local vco = core:get_static_object("vco");
 local vlc = core:get_static_object("vco-lib-commons");
 
 local FACTION_WUL_KEY = "wh_dlc08_nor_norsca";
+local SUBCULTURE_KEY = "wh_dlc08_sc_nor_norsca";
 local MONSTER_HUNT_MISSION_KEYS = {
 	"wh_dlc08_qb_nor_monster_hunt_0",
 	"wh_dlc08_qb_nor_monster_hunt_1",
@@ -22,11 +23,11 @@ local UNLOCKABLE_NURGLE_UNITS = {	"wh3_main_nur_inf_plaguebearers_0", "wh3_main_
 local UNLOCKABLE_TZEENTCH_UNITS = {	"wh3_main_tze_inf_pink_horrors_0", "wh3_main_tze_inf_pink_horrors_1" }
 local UNLOCKABLE_SLAANESH_UNITS = { "wh3_main_sla_inf_daemonette_0", "wh3_main_sla_inf_daemonette_1" }
 
-local function wul_lock_units()
-	vlc.unit_locks:lock_units(UNLOCKABLE_KHORNE_UNITS, FACTION_WUL_KEY);
-	vlc.unit_locks:lock_units(UNLOCKABLE_NURGLE_UNITS, FACTION_WUL_KEY);
-	vlc.unit_locks:lock_units(UNLOCKABLE_TZEENTCH_UNITS, FACTION_WUL_KEY);
-	vlc.unit_locks:lock_units(UNLOCKABLE_SLAANESH_UNITS, FACTION_WUL_KEY);
+local function lock_units()
+	vlc.unit_locks:lock_units_by_subculture(UNLOCKABLE_KHORNE_UNITS, SUBCULTURE_KEY);
+	vlc.unit_locks:lock_units_by_subculture(UNLOCKABLE_NURGLE_UNITS, SUBCULTURE_KEY);
+	vlc.unit_locks:lock_units_by_subculture(UNLOCKABLE_TZEENTCH_UNITS, SUBCULTURE_KEY);
+	vlc.unit_locks:lock_units_by_subculture(UNLOCKABLE_SLAANESH_UNITS, SUBCULTURE_KEY);
 end
 
 local function wul_unlock_units(pooled_resource)
@@ -98,7 +99,7 @@ local function add_listeners()
 			return cm:model():turn_number() == 1 and
 				context:faction():name() == FACTION_WUL_KEY;
 		end,
-		wul_lock_units,
+		lock_units,
 		false
 	);
 


### PR DESCRIPTION
* Prevent other factions within races accessing unlockable units
* Applied to Kislev + Norsca
* No need to apply to Morathi - she has her own group due to having Slaanesh units by default where other DEF don't.