### PR TITLE
Fix Nagash Books completion

### DIFF
--- a/src/script/_lib/mod/vco-commons.lua
+++ b/src/script/_lib/mod/vco-commons.lua
@@ -95,23 +95,23 @@ end
 -- ITEMS --
 
 function vlc.items:add_item_to_faction_inventory(item_key, faction_key)
-    local faction = cm:get_faction(faction_key);
-    cm:add_ancillary_to_faction(faction, item_key, false);
+	local faction = cm:get_faction(faction_key);
+	cm:add_ancillary_to_faction(faction, item_key, false);
 end
 
 -- NAGASH BOOKS --
 
-function vlc.nagash_books:add(faction_id, book_number)
-	vco:log("Book of Nagash collected (" .. faction_id .. "): " .. book_number);
-	cm:set_saved_value("vco_" .. faction_id .. "_book_" .. book_number .. "_collected", true);
+function vlc.nagash_books:add(faction_key, book_number)
+	vco:log("Book of Nagash collected (" .. faction_key .. "): " .. book_number);
+	cm:set_saved_value("vco_" .. faction_key .. "_book_" .. book_number .. "_collected", true);
 end
 
-function vlc.nagash_books:count(faction_id)
-	vco:log("Counting Books of Nagash (" .. faction_id .. ")");
+function vlc.nagash_books:count(faction_key)
+	vco:log("Counting Books of Nagash (" .. faction_key .. ")");
 	local count_collected_books = 0;
 
 	for book_number=1, 9 do
-		if cm:get_saved_value("vco_" .. faction_id .. "_book_" .. book_number .. "_collected") then
+		if cm:get_saved_value("vco_" .. faction_key .. "_book_" .. book_number .. "_collected") then
 			vco:log("- Book " .. book_number .. " OK");
 			count_collected_books = count_collected_books + 1;
 		end
@@ -121,19 +121,19 @@ function vlc.nagash_books:count(faction_id)
 	return count_collected_books;
 end
 
-function vlc.nagash_books:check_generic_all_books_collected(faction_id, mission, max_books)
-	vco:log("Checking Books of Nagash (" .. faction_id .. ") | Triggered by " .. mission:mission_record_key());
+function vlc.nagash_books:check_generic_all_books_collected(faction_key, mission, max_books)
+	vco:log("Checking Books of Nagash (" .. faction_key .. ") | Triggered by " .. mission:mission_record_key());
 	local book_number = string.sub(mission:mission_record_key(), -1);
-	self:add(faction_id, book_number);
+	self:add(faction_key, book_number);
 
-	local count_books = self:count(faction_id);
+	local count_books = self:count(faction_key);
 	if count_books < max_books then
 		vco:log("Checking Books of Nagash | Count updated");
-		vco:set_mission_text("vco_" .. faction_id.. "_nagash_books", "vco_common_nagash_books_collected_" .. count_books);
+		vco:set_mission_text("vco_" .. faction_key .. "_nagash_books", "vco_common_nagash_books_collected_" .. count_books);
 	else
 		vco:log("Checking Books of Nagash | Mission completed");
-		vco:set_mission_text("vco_" .. faction_id .. "_nagash_books", "vco_common_nagash_books_collected");
-		vco:complete_mission(faction_id, "vco_" .. faction_id .. "_nagash_books");
+		vco:set_mission_text("vco_" .. faction_key .. "_nagash_books", "vco_common_nagash_books_collected");
+		vco:complete_mission(faction_key, "vco_" .. faction_key .. "_nagash_books");
 	end
 end
 

--- a/src/script/campaign/mod/vco-listeners-tmb.lua
+++ b/src/script/campaign/mod/vco-listeners-tmb.lua
@@ -21,7 +21,7 @@ local function add_listeners()
 				context:mission():mission_record_key():sub(1,26) == "wh2_dlc09_books_of_nagash_";
 		end,
 		function(context)
-			vlc.nagash_books:add(FACTION_ARK_ID, 9);
+			vlc.nagash_books:add(FACTION_ARK_ID, 8);
 			check_ark_collected_books(context:mission());
 		end,
 		true

--- a/src/script/campaign/mod/vco-listeners-tmb.lua
+++ b/src/script/campaign/mod/vco-listeners-tmb.lua
@@ -6,7 +6,7 @@ local FACTION_ARK_KEY = "wh2_dlc09_tmb_followers_of_nagash";
 -- CHECKS --
 
 local function check_ark_collected_books(mission)
-	vlc.nagash_books:check_generic_all_books_collected(FACTION_ARK_ID, mission, 9);
+	vlc.nagash_books:check_generic_all_books_collected(FACTION_ARK_KEY, mission, 9);
 end
 
 -- LISTENERS --

--- a/src/script/campaign/mod/vco-listeners-vmp.lua
+++ b/src/script/campaign/mod/vco-listeners-vmp.lua
@@ -39,7 +39,7 @@ end
 -- CHECKS --
 
 local function check_man_collected_books(mission)
-	vlc.nagash_books:check_generic_all_books_collected(FACTION_MAN_ID, mission, 8);
+	vlc.nagash_books:check_generic_all_books_collected(FACTION_MAN_KEY, mission, 8);
 end
 
 -- LISTENERS --

--- a/src/script/vco-ie/main_warhammer/wh2_dlc09_tmb_followers_of_nagash/missions.lua
+++ b/src/script/vco-ie/main_warhammer/wh2_dlc09_tmb_followers_of_nagash/missions.lua
@@ -135,7 +135,7 @@ local missions = {
 				{
 					override_text mission_text_text_vco_common_nagash_books_collected_1;
 					type SCRIPTED;
-					script_key vco_tmb_ark_nagash_books;
+					script_key vco_wh2_dlc09_tmb_followers_of_nagash_nagash_books;
 				}
 
 				payload

--- a/src/script/vco-ie/main_warhammer/wh_main_vmp_vampire_counts/missions.lua
+++ b/src/script/vco-ie/main_warhammer/wh_main_vmp_vampire_counts/missions.lua
@@ -158,7 +158,7 @@ local missions = {
 				{
 					override_text mission_text_text_vco_common_nagash_books_collected_0;
 					type SCRIPTED;
-					script_key vco_vmp_man_nagash_books;
+					script_key vco_wh_main_vmp_vampire_counts_nagash_books;
 				}
 
 				payload


### PR DESCRIPTION
Why did you use faction id we always use faction key. It wouldn't have mattered except for one line: `complete_mission` requires factionkey not id.